### PR TITLE
feat: apply green theme to login screen

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { TextField, Button, Paper, Typography, Box } from "@mui/material";
+import { useTheme } from "../contexts/ThemeContext";
+import { getCommonStyles } from "../themes/commonComponents";
 import { useAuth } from "../api/queries/useAuth";
 import { showToast } from "../utils/toast";
 
@@ -8,6 +10,8 @@ export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const { loginMutation } = useAuth();
+  const { currentTheme } = useTheme();
+  const styles = getCommonStyles(currentTheme);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,9 +34,30 @@ export default function Login() {
       justifyContent="center"
       alignItems="center"
       minHeight="80vh"
+      sx={{
+        backgroundColor: currentTheme.background.primary,
+        color: currentTheme.text.primary,
+      }}
     >
-      <Paper elevation={3} sx={{ p: 4, width: "100%", maxWidth: 400 }}>
-        <Typography variant="h5" component="h1" gutterBottom>
+      <Paper
+        elevation={3}
+        sx={{
+          p: 4,
+          width: "100%",
+          maxWidth: 400,
+          ...styles.paper,
+          backgroundColor: currentTheme.background.secondary,
+        }}
+      >
+        <Typography
+          variant="h5"
+          component="h1"
+          gutterBottom
+          sx={{
+            fontWeight: currentTheme.typography.fontWeights.heading,
+            color: currentTheme.text.primary,
+          }}
+        >
           Login
         </Typography>
         <form onSubmit={handleSubmit}>
@@ -44,6 +69,22 @@ export default function Login() {
             onChange={(e) => setEmail(e.target.value)}
             type="email"
             required
+            sx={{
+              '& label.Mui-focused': {
+                color: currentTheme.accent.primary,
+              },
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: currentTheme.accent.secondary,
+                },
+                '&:hover fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+              },
+            }}
           />
           <TextField
             fullWidth
@@ -53,19 +94,46 @@ export default function Login() {
             onChange={(e) => setPassword(e.target.value)}
             type="password"
             required
+            sx={{
+              '& label.Mui-focused': {
+                color: currentTheme.accent.primary,
+              },
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: currentTheme.accent.secondary,
+                },
+                '&:hover fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+              },
+            }}
           />
           <Button
             fullWidth
             variant="contained"
-            color="primary"
             type="submit"
-            sx={{ mt: 2 }}
+            sx={{
+              mt: 2,
+              backgroundColor: currentTheme.accent.primary,
+              color: "#fff",
+              '&:hover': {
+                backgroundColor: currentTheme.accent.secondary,
+              },
+            }}
             disabled={loginMutation.isPending}
           >
             {loginMutation.isPending ? "Logging in..." : "Login"}
           </Button>
           <Box mt={2} textAlign="center">
-            <Link to="/signup">Don't have an account? Sign up</Link>
+            <Link
+              to="/signup"
+              style={{ color: currentTheme.accent.primary }}
+            >
+              Don't have an account? Sign up
+            </Link>
           </Box>
         </form>
       </Paper>


### PR DESCRIPTION
## Summary
- style login page with app's green trading theme using ThemeContext
- apply theme colors to fields, button and links for cohesive look

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68a94fa70a808325a091ae7a5a6c3a01