### PR TITLE
feat: apply green theme to auth screens

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { TextField, Button, Paper, Typography, Box } from "@mui/material";
+import { useTheme } from "../contexts/ThemeContext";
+import { getCommonStyles } from "../themes/commonComponents";
 import { useAuth } from "../api/queries/useAuth";
 import { showToast } from "../utils/toast";
 
@@ -8,6 +10,8 @@ export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const { loginMutation } = useAuth();
+  const { currentTheme } = useTheme();
+  const styles = getCommonStyles(currentTheme);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,9 +34,30 @@ export default function Login() {
       justifyContent="center"
       alignItems="center"
       minHeight="80vh"
+      sx={{
+        backgroundColor: currentTheme.background.primary,
+        color: currentTheme.text.primary,
+      }}
     >
-      <Paper elevation={3} sx={{ p: 4, width: "100%", maxWidth: 400 }}>
-        <Typography variant="h5" component="h1" gutterBottom>
+      <Paper
+        elevation={3}
+        sx={{
+          p: 4,
+          width: "100%",
+          maxWidth: 400,
+          ...styles.paper,
+          backgroundColor: currentTheme.background.secondary,
+        }}
+      >
+        <Typography
+          variant="h5"
+          component="h1"
+          gutterBottom
+          sx={{
+            fontWeight: currentTheme.typography.fontWeights.heading,
+            color: currentTheme.text.primary,
+          }}
+        >
           Login
         </Typography>
         <form onSubmit={handleSubmit}>
@@ -44,6 +69,22 @@ export default function Login() {
             onChange={(e) => setEmail(e.target.value)}
             type="email"
             required
+            sx={{
+              '& label.Mui-focused': {
+                color: currentTheme.accent.primary,
+              },
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: currentTheme.accent.secondary,
+                },
+                '&:hover fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+              },
+            }}
           />
           <TextField
             fullWidth
@@ -53,19 +94,46 @@ export default function Login() {
             onChange={(e) => setPassword(e.target.value)}
             type="password"
             required
+            sx={{
+              '& label.Mui-focused': {
+                color: currentTheme.accent.primary,
+              },
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: currentTheme.accent.secondary,
+                },
+                '&:hover fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+              },
+            }}
           />
           <Button
             fullWidth
             variant="contained"
-            color="primary"
             type="submit"
-            sx={{ mt: 2 }}
+            sx={{
+              mt: 2,
+              backgroundColor: currentTheme.accent.primary,
+              color: "#fff",
+              '&:hover': {
+                backgroundColor: currentTheme.accent.secondary,
+              },
+            }}
             disabled={loginMutation.isPending}
           >
             {loginMutation.isPending ? "Logging in..." : "Login"}
           </Button>
           <Box mt={2} textAlign="center">
-            <Link to="/signup">Don't have an account? Sign up</Link>
+            <Link
+              to="/signup"
+              style={{ color: currentTheme.accent.primary }}
+            >
+              Don't have an account? Sign up
+            </Link>
           </Box>
         </form>
       </Paper>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { TextField, Button, Paper, Typography, Box } from "@mui/material";
+import { useTheme } from "../contexts/ThemeContext";
+import { getCommonStyles } from "../themes/commonComponents";
 import { useAuth } from "../api/queries/useAuth";
 import { showToast } from "../utils/toast";
 
@@ -9,6 +11,8 @@ export default function Signup() {
   const [password, setPassword] = useState("");
   const [fullName, setFullName] = useState("");
   const { signupMutation } = useAuth();
+  const { currentTheme } = useTheme();
+  const styles = getCommonStyles(currentTheme);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -31,9 +35,30 @@ export default function Signup() {
       justifyContent="center"
       alignItems="center"
       minHeight="80vh"
+      sx={{
+        backgroundColor: currentTheme.background.primary,
+        color: currentTheme.text.primary,
+      }}
     >
-      <Paper elevation={3} sx={{ p: 4, width: "100%", maxWidth: 400 }}>
-        <Typography variant="h5" component="h1" gutterBottom>
+      <Paper
+        elevation={3}
+        sx={{
+          p: 4,
+          width: "100%",
+          maxWidth: 400,
+          ...styles.paper,
+          backgroundColor: currentTheme.background.secondary,
+        }}
+      >
+        <Typography
+          variant="h5"
+          component="h1"
+          gutterBottom
+          sx={{
+            fontWeight: currentTheme.typography.fontWeights.heading,
+            color: currentTheme.text.primary,
+          }}
+        >
           Sign Up
         </Typography>
         <form onSubmit={handleSubmit}>
@@ -44,6 +69,22 @@ export default function Signup() {
             value={fullName}
             onChange={(e) => setFullName(e.target.value)}
             required
+            sx={{
+              '& label.Mui-focused': {
+                color: currentTheme.accent.primary,
+              },
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: currentTheme.accent.secondary,
+                },
+                '&:hover fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+              },
+            }}
           />
           <TextField
             fullWidth
@@ -53,6 +94,22 @@ export default function Signup() {
             onChange={(e) => setEmail(e.target.value)}
             type="email"
             required
+            sx={{
+              '& label.Mui-focused': {
+                color: currentTheme.accent.primary,
+              },
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: currentTheme.accent.secondary,
+                },
+                '&:hover fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+              },
+            }}
           />
           <TextField
             fullWidth
@@ -62,19 +119,43 @@ export default function Signup() {
             onChange={(e) => setPassword(e.target.value)}
             type="password"
             required
+            sx={{
+              '& label.Mui-focused': {
+                color: currentTheme.accent.primary,
+              },
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: currentTheme.accent.secondary,
+                },
+                '&:hover fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: currentTheme.accent.primary,
+                },
+              },
+            }}
           />
           <Button
             fullWidth
             variant="contained"
-            color="primary"
             type="submit"
-            sx={{ mt: 2 }}
+            sx={{
+              mt: 2,
+              backgroundColor: currentTheme.accent.primary,
+              color: "#fff",
+              '&:hover': {
+                backgroundColor: currentTheme.accent.secondary,
+              },
+            }}
             disabled={signupMutation.isPending}
           >
             {signupMutation.isPending ? "Signing up..." : "Sign Up"}
           </Button>
           <Box mt={2} textAlign="center">
-            <Link to="/login">Already have an account? Login</Link>
+            <Link to="/login" style={{ color: currentTheme.accent.primary }}>
+              Already have an account? Login
+            </Link>
           </Box>
         </form>
       </Paper>


### PR DESCRIPTION
## Summary
- style login page with app's green trading theme using ThemeContext
- apply same cohesive theme styling to signup page fields, button and links

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68a94fa70a808325a091ae7a5a6c3a01