### PR TITLE
Improve dashboard mobile layout

### DIFF
--- a/src/components/LeaderboardCard.tsx
+++ b/src/components/LeaderboardCard.tsx
@@ -52,95 +52,87 @@ const LeaderboardCard: React.FC<LeaderboardCardProps> = ({
   return (
     <Box
       onClick={() => navigate(`/portfolio/${row.portfolioId}`)}
-      sx={{
-        cursor: "pointer",
-        borderRadius: 0,
-        paddingLeft: 2,
-        paddingRight: 2,
-        paddingTop: 1,
-        paddingBottom: 1,
-      }}
+      sx={{ cursor: "pointer" }}
     >
-      <Stack spacing={0}>
-        <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
-          {
+      <Stack spacing={1}>
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          {index === 0 ? (
+            <EmojiEventsIcon
+              sx={{
+                color: "#FFD700",
+                animation: "bounce 2s infinite",
+                "@keyframes bounce": {
+                  "0%, 100%": { transform: "translateY(0)" },
+                  "50%": { transform: "translateY(-3px)" },
+                },
+              }}
+            />
+          ) : (
             <Box
               sx={{
-                display: "flex",
-                alignItems: "center",
+                px: 1,
+                py: 0.25,
+                borderRadius: 1,
+                backgroundColor: currentTheme.accent.primary,
+                color: "white",
+                fontSize: "0.75rem",
+                fontWeight: 600,
+                minWidth: 28,
+                textAlign: "center",
               }}
             >
-              {index === 0 ? (
-                <EmojiEventsIcon
-                  sx={{
-                    color: "#FFD700",
-                    animation: "bounce 2s infinite",
-                    "@keyframes bounce": {
-                      "0%, 100%": { transform: "translateY(0)" },
-                      "50%": { transform: "translateY(-3px)" },
-                    },
-                  }}
-                />
-              ) : (
-                <Typography
-                  variant="h6"
-                  sx={{ color: currentTheme.accent.secondary }}
-                >
-                  {index + 1 + (index === 1 ? "nd" : index === 2 ? "rd" : "th")}{" "}
-                  •
-                </Typography>
-              )}
+              #{index + 1}
             </Box>
-          }
-          <Typography variant="h6" component="div">
-            <Stack direction="row" spacing={1} alignItems="center">
-              <Typography>{row.portfolioName}</Typography>
-              {renderPrivacyIcon()}
-              {row.userName !== "Anonymous User" && (
-                <Stack direction="row" justifyContent="space-between">
-                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                    by {row.userName}
-                  </Typography>
-                </Stack>
-              )}
-            </Stack>
-          </Typography>
-        </Stack>
-
-        <Stack spacing={2}>
-          <Stack direction="row" justifyContent="space-between">
-            <Box>
-              <Typography variant="body2">
-                {formatPerformance(row.performance1D)}
-              </Typography>
-              <Typography variant="body2">1 Day</Typography>
-            </Box>
-            <Box>
-              <Typography variant="body2">
-                {formatPerformance(row.performance1W)}
-              </Typography>
-              <Typography variant="body2">1 Week</Typography>
-            </Box>
-            <Box>
-              <Typography variant="body2">
-                {formatPerformance(row.performance1M)}
-              </Typography>
-              <Typography variant="body2">1 Month</Typography>
-            </Box>
-          </Stack>
-
-          {!showLimitedInfo && (
-            <Stack direction="row" justifyContent="space-between">
-              <Typography variant="body2">
-                {row.updatedAt
-                  ? `Last updated ${formatDistanceToNow(
-                      new Date(row.updatedAt)
-                    )} ago`
-                  : ""}
-              </Typography>
-            </Stack>
           )}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="subtitle1" fontWeight={600} noWrap>
+              {row.portfolioName}
+            </Typography>
+            {row.userName !== "Anonymous User" && (
+              <Typography variant="caption" color="text.secondary" noWrap>
+                by {row.userName}
+              </Typography>
+            )}
+          </Box>
+          {renderPrivacyIcon()}
         </Stack>
+
+        <Stack direction="row" justifyContent="space-between" textAlign="center">
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {formatPerformance(row.performance1D)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              1 Day
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {formatPerformance(row.performance1W)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              1 Week
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {formatPerformance(row.performance1M)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              1 Month
+            </Typography>
+          </Box>
+        </Stack>
+
+        {!showLimitedInfo && (
+          <Typography variant="caption" color="text.secondary">
+            {row.updatedAt
+              ? `Last updated ${formatDistanceToNow(
+                  new Date(row.updatedAt)
+                )} ago`
+              : ""}
+          </Typography>
+        )}
       </Stack>
     </Box>
   );

--- a/src/components/common/TableView.tsx
+++ b/src/components/common/TableView.tsx
@@ -118,17 +118,18 @@ const TableView = ({
   };
 
   const renderCardView = () => (
-    <Stack spacing={isCompact ? 0 : 1}>
+    <Stack spacing={1}>
       {tableData.map((row, rowIndex) => (
         <Card
           key={row.id || rowIndex}
           sx={{
             backgroundColor: currentTheme.background.secondary,
-            borderRadius: 0,
-            borderBottom: "0.5px solid #e0e0e0",
+            borderRadius: 2,
+            border: "1px solid rgba(0,0,0,0.06)",
+            boxShadow: "0 1px 2px rgba(0,0,0,0.08)",
           }}
         >
-          <CardContent sx={{ p: isCompact ? 1 : 2 }}>
+          <CardContent sx={{ px: 2, py: isCompact ? 1 : 2 }}>
             {customCardComponent ? (
               customCardComponent(row, rowIndex)
             ) : (

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -33,11 +33,18 @@ export const formatPerformance = (value: number | string) => {
   }
 
   const numValue = typeof value === "string" ? parseFloat(value) : value;
-  const color = numValue >= 0 ? "text-green-600" : "text-red-600";
+
+  if (numValue === 0) {
+    return <span className="text-gray-500">–</span>;
+  }
+
+  const isPositive = numValue > 0;
+  const color = isPositive ? "text-green-600" : "text-red-600";
+  const symbol = isPositive ? "▲" : "▼";
+
   return (
-    <span className={color}>
-      {numValue >= 0 ? "+" : ""}
-      {numValue.toFixed(2)}%
+    <span className={`${color} font-medium`}>
+      {symbol} {Math.abs(numValue).toFixed(2)}%
     </span>
   );
 };


### PR DESCRIPTION
## Summary
- Show arrow indicators and dash for neutral portfolio performance values
- Restyle card view with rounded corners and soft shadow for mobile tables
- Revamp leaderboard card with rank badge and compact typography

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68a98ddba4b08325ab10bc2727c267fa