### PR TITLE
Add padding to watch list heading on dashboard

### DIFF
--- a/src/components/WatchListTable.tsx
+++ b/src/components/WatchListTable.tsx
@@ -95,7 +95,7 @@ const WatchListTable: React.FC = () => {
 
   return (
     <Box sx={{ mt: 4, mb: 4 }}>
-      <Box sx={{ mb: 2 }}>
+      <Box sx={{ mb: 2, paddingLeft: { xs: 2, sm: 0 } }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
           <VisibilityIcon fontSize="small" aria-hidden />
           <Typography variant="body1" component="h2" sx={{ fontWeight: "bold" }}>


### PR DESCRIPTION
## Summary
- add responsive left padding to "Your Watch List" section for consistent spacing with NEPSE Leaderboard

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68aa19af8a888325ba8564fdcf13316b