### PR TITLE
feat: add mobile watchlist row

### DIFF
--- a/src/components/WatchListCard.tsx
+++ b/src/components/WatchListCard.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Box, Stack, Typography, IconButton, Tooltip } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import StockLink from "./common/StockLink";
+import { formatPerformance } from "../pages/Leaderboard";
+import type { WatchListEntry } from "../types/api";
+
+interface WatchListCardProps {
+  row: WatchListEntry;
+  onRemove: (id: number) => void;
+}
+
+const WatchListCard: React.FC<WatchListCardProps> = ({ row, onRemove }) => {
+  return (
+    <Box>
+      <Stack spacing={1}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle1" fontWeight={600} noWrap>
+              {row.symbol ? <StockLink symbol={row.symbol} /> : "-"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" noWrap>
+              {row.name || "-"}
+            </Typography>
+          </Box>
+          <Tooltip title="Remove from watch list">
+            <IconButton
+              size="small"
+              onClick={() => onRemove(row.id)}
+              sx={{
+                color: "error.main",
+                "&:hover": { backgroundColor: "error.lighter" },
+              }}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+        <Stack direction="row" justifyContent="space-between" textAlign="center">
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {row.latestPrice ? `Rs. ${row.latestPrice}` : "-"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Latest Price
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {row.performance1D ? formatPerformance(row.performance1D) : "-"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              1 Day
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {row.performance1W ? formatPerformance(row.performance1W) : "-"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              1 Week
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              {row.performance1M ? formatPerformance(row.performance1M) : "-"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              1 Month
+            </Typography>
+          </Box>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};
+
+export default WatchListCard;

--- a/src/components/WatchListTable.tsx
+++ b/src/components/WatchListTable.tsx
@@ -8,6 +8,7 @@ import { showToast } from "../utils/toast";
 import TableView from "./common/TableView";
 import { ColumnConfig } from "./common/TableView";
 import StockLink from "./common/StockLink";
+import WatchListCard from "./WatchListCard";
 
 const WatchListTable: React.FC = () => {
   const { watchList, isLoading, removeFromWatchList } = useWatchListContext();
@@ -118,7 +119,14 @@ const WatchListTable: React.FC = () => {
           Your watch list is empty. Add stocks to track them here!
         </Typography>
       ) : (
-        <TableView columns={columns} tableData={watchList} isCompact />
+        <TableView
+          columns={columns}
+          tableData={watchList}
+          isCompact
+          customCardComponent={(row) => (
+            <WatchListCard row={row} onRemove={handleRemoveFromWatchList} />
+          )}
+        />
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary
- implement `WatchListCard` to show watch list entries in mobile view
- wire `WatchListTable` to use the custom card component with all existing fields

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68aa1a3c0174832590fdbc984f618552