### PR TITLE
feat: redesign public portfolio view

### DIFF
--- a/src/pages/SharedPortfolio.tsx
+++ b/src/pages/SharedPortfolio.tsx
@@ -1,36 +1,41 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
+import { usePublicPortfolio } from "../api/queries/usePortfolios";
+import {
+  Avatar,
+  Box,
+  Stack,
+  Tooltip as MuiTooltip,
+  Typography,
+} from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import LockIcon from "@mui/icons-material/Lock";
+import PublicIcon from "@mui/icons-material/Public";
+import CategoryIcon from "@mui/icons-material/Category";
+import TableChartIcon from "@mui/icons-material/TableChart";
+import ViewListIcon from "@mui/icons-material/ViewList";
+import { PortfolioPrivacy } from "../types/api";
+import { useTheme } from "../contexts/ThemeContext";
 import {
   PieChart,
   Pie,
   Cell,
   Tooltip as RechartTooltip,
-  Legend,
   ResponsiveContainer,
 } from "recharts";
-import { usePublicPortfolio } from "../api/queries/usePortfolios";
 import TableView, { ColumnConfig } from "../components/common/TableView";
-import { Link as RouterLink } from "react-router-dom";
-import { formatPerformance } from "./Leaderboard";
-import Tooltip from "../components/common/Tooltip";
-import { format } from "date-fns";
-import { Stack, Box, Tooltip as MuiTooltip, Typography } from "@mui/material";
-import LockIcon from "@mui/icons-material/Lock";
-import PublicIcon from "@mui/icons-material/Public";
-import CategoryIcon from "@mui/icons-material/Category";
-import { PortfolioPrivacy } from "../types/api";
 import StockSymbolLink from "../components/common/StockSymbolLink";
-import { useTheme } from "../contexts/ThemeContext";
+import Tooltip from "../components/common/Tooltip";
+import { formatPerformance } from "./Leaderboard";
+import { format } from "date-fns";
 
 const SharedPortfolio: React.FC = () => {
   const { currentTheme } = useTheme();
   const { id } = useParams<{ id: string }>();
 
-  const {
-    data: publicPortfolio,
-    isLoading,
-    error,
-  } = usePublicPortfolio(Number(id));
+  const { data: publicPortfolio, isLoading, error } = usePublicPortfolio(
+    Number(id)
+  );
 
   const columns: ColumnConfig[] = [
     {
@@ -103,7 +108,16 @@ const SharedPortfolio: React.FC = () => {
     },
   ];
 
-  // Add chart dimensions state
+  const sortedStocks = React.useMemo(
+    () =>
+      [...(publicPortfolio?.portfolioStocks || [])].sort(
+        (a, b) => b.percentage - a.percentage
+      ),
+    [publicPortfolio?.portfolioStocks]
+  );
+
+  const [viewMode, setViewMode] = React.useState<"list" | "table">("list");
+
   const [chartDimensions, setChartDimensions] = React.useState({
     height: 350,
     outerRadius: 100,
@@ -128,15 +142,33 @@ const SharedPortfolio: React.FC = () => {
       }
     };
 
-    // Set initial dimensions
     handleResize();
-
-    // Add event listener
     window.addEventListener("resize", handleResize);
-
-    // Cleanup
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  const renderPieChartContent = () => (
+    <PieChart>
+      <Pie
+        data={publicPortfolio?.portfolioStocks}
+        dataKey="percentage"
+        nameKey="symbol"
+        cx="50%"
+        cy="50%"
+        outerRadius={chartDimensions.outerRadius}
+        fill={currentTheme.accent.primary}
+        label={({ symbol, percent }) => `${symbol} ${(percent * 100).toFixed(0)}%`}
+      >
+        {publicPortfolio?.portfolioStocks?.map((entry, index) => (
+          <Cell
+            key={`cell-${index}`}
+            fill={COLORS[index % COLORS.length]}
+          />
+        ))}
+      </Pie>
+      <RechartTooltip />
+    </PieChart>
+  );
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error loading portfolio</div>;
@@ -144,25 +176,129 @@ const SharedPortfolio: React.FC = () => {
 
   return (
     <div className="mx-auto">
-      <Box className="flex items-center gap-2 mb-4 mt-4">
-        <Typography
-          variant="subtitle1"
-          component="h1"
-          sx={{ color: currentTheme.text.primary }}
-        >
-          {publicPortfolio.name}
-        </Typography>
-        <MuiTooltip title={getPrivacyInfo(publicPortfolio.privacy).text}>
-          <span style={{ color: currentTheme.text.secondary }}>
-            {getPrivacyInfo(publicPortfolio.privacy).icon}
-          </span>
-        </MuiTooltip>
+      <Box className="flex items-center justify-between gap-2 mb-4 mt-4">
+        <Box className="flex items-center gap-2">
+          <Typography
+            variant="subtitle1"
+            component="h1"
+            sx={{ color: currentTheme.text.primary }}
+          >
+            {publicPortfolio.name}
+          </Typography>
+          <MuiTooltip title={getPrivacyInfo(publicPortfolio.privacy).text}>
+            <span style={{ color: currentTheme.text.secondary }}>
+              {getPrivacyInfo(publicPortfolio.privacy).icon}
+            </span>
+          </MuiTooltip>
+        </Box>
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <ViewListIcon
+            onClick={() => setViewMode("list")}
+            sx={{
+              cursor: "pointer",
+              color:
+                viewMode === "list"
+                  ? currentTheme.accent.primary
+                  : currentTheme.text.secondary,
+            }}
+          />
+          <TableChartIcon
+            onClick={() => setViewMode("table")}
+            sx={{
+              cursor: "pointer",
+              color:
+                viewMode === "table"
+                  ? currentTheme.accent.primary
+                  : currentTheme.text.secondary,
+            }}
+          />
+        </Box>
       </Box>
 
       {publicPortfolio.privacy === PortfolioPrivacy.PRIVATE ? (
-        <div style={{ color: currentTheme.text.primary }}>
-          Private Portfolio
-        </div>
+        <div style={{ color: currentTheme.text.primary }}>Private Portfolio</div>
+      ) : viewMode === "list" ? (
+        <Box>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              mb: 1,
+              color: currentTheme.text.secondary,
+            }}
+          >
+            <Typography variant="body2">Stock</Typography>
+            <Typography variant="body2">Weight</Typography>
+          </Box>
+          <Stack spacing={1}>
+            {sortedStocks.map((stock) => {
+              const displayName = stock.name || stock.symbol;
+              const initials = displayName?.charAt(0) || "";
+              return (
+                <Box
+                  key={stock.symbol}
+                  sx={{
+                    position: "relative",
+                    display: "flex",
+                    alignItems: "center",
+                    p: 1.5,
+                    borderRadius: 4,
+                    backgroundColor: currentTheme.background.secondary,
+                    overflow: "hidden",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      bottom: 0,
+                      width: `${stock.percentage}%`,
+                      backgroundColor: alpha(
+                        currentTheme.accent.primary,
+                        currentTheme.name === "Dark Theme" ? 0.4 : 0.2
+                      ),
+                    }}
+                  />
+                  <Avatar
+                    sx={{
+                      bgcolor: currentTheme.accent.primary,
+                      mr: 2,
+                      zIndex: 1,
+                    }}
+                  >
+                    {initials}
+                  </Avatar>
+                  <Typography
+                    sx={{ color: currentTheme.text.primary, zIndex: 1 }}
+                  >
+                    {displayName}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      ml: "auto",
+                      color: currentTheme.text.primary,
+                      zIndex: 1,
+                    }}
+                  >
+                    {stock.percentage.toFixed(2)}%
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Stack>
+          <Box
+            sx={{
+              mt: 4,
+              height: chartDimensions.height,
+              fontSize: chartDimensions.fontSize,
+            }}
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              {renderPieChartContent()}
+            </ResponsiveContainer>
+          </Box>
+        </Box>
       ) : (
         <Stack
           direction={{ xs: "column", md: "row" }}
@@ -181,7 +317,6 @@ const SharedPortfolio: React.FC = () => {
               isCompact
             />
           </Box>
-
           <Box
             sx={{
               flex: "0 0 40%",
@@ -189,35 +324,29 @@ const SharedPortfolio: React.FC = () => {
               fontSize: chartDimensions.fontSize,
             }}
           >
-            <ResponsiveContainer width="100%" height={chartDimensions.height}>
-              <PieChart>
-                <Pie
-                  data={publicPortfolio.portfolioStocks}
-                  dataKey="percentage"
-                  nameKey="symbol"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={chartDimensions.outerRadius}
-                  fill={currentTheme.accent.primary}
-                  label={({ symbol, percent }) =>
-                    `${symbol} ${(percent * 100).toFixed(0)}%`
-                  }
-                >
-                  {publicPortfolio.portfolioStocks?.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={COLORS[index % COLORS.length]}
-                    />
-                  ))}
-                </Pie>
-                <RechartTooltip />
-              </PieChart>
+            <ResponsiveContainer
+              width="100%"
+              height={chartDimensions.height}
+            >
+              {renderPieChartContent()}
             </ResponsiveContainer>
           </Box>
         </Stack>
       )}
     </div>
   );
+};
+const getPrivacyInfo = (privacy: string) => {
+  switch (privacy) {
+    case "PRIVATE":
+      return { icon: <LockIcon />, text: "Private Portfolio" };
+    case "SHARE_ALL":
+      return { icon: <PublicIcon />, text: "Showing All Holdings" };
+    case "SHARE_SECTORS":
+      return { icon: <CategoryIcon />, text: "Showing Sector-wise Holdings" };
+    default:
+      return { icon: <PublicIcon />, text: "Public Portfolio" };
+  }
 };
 
 const COLORS = [
@@ -274,15 +403,3 @@ const PriceChangeTooltip = ({
   );
 };
 
-const getPrivacyInfo = (privacy: string) => {
-  switch (privacy) {
-    case "PRIVATE":
-      return { icon: <LockIcon />, text: "Private Portfolio" };
-    case "SHARE_ALL":
-      return { icon: <PublicIcon />, text: "Showing All Holdings" };
-    case "SHARE_SECTORS":
-      return { icon: <CategoryIcon />, text: "Showing Sector-wise Holdings" };
-    default:
-      return { icon: <PublicIcon />, text: "Public Portfolio" };
-  }
-};


### PR DESCRIPTION
## Summary
- restyle shared portfolio page to show stock allocation list with avatar initials and weight bars
- reintroduce responsive pie chart below the allocation list
- fall back to stock symbol for avatar and label when name is missing
- add toggle icons to switch between new allocation list and detailed table view

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68b34eb098808325a74e809a41ec86f6