### PR TITLE
feat: show profit/loss per stock

### DIFF
--- a/src/components/PortfolioTable.tsx
+++ b/src/components/PortfolioTable.tsx
@@ -95,13 +95,15 @@ const PORTFOLIO_TABLE_HEADERS_FROM_DB: Array<ColumnConfig> = [
       const buyPrice = stock.buyPrice ?? 0;
       const currentPrice = stock.latestClosingPrice ?? 0;
       const profitLoss = (currentPrice - buyPrice) * stock.quantity;
+      const profitLossPercent =
+        buyPrice !== 0 ? ((currentPrice - buyPrice) / buyPrice) * 100 : 0;
 
       return (
         <Typography
           variant="body2"
           sx={{ color: profitLoss >= 0 ? "success.main" : "error.main" }}
         >
-          {formatAmount(profitLoss, true)}
+          {formatAmount(profitLoss, true)} ({profitLossPercent.toFixed(2)}%)
         </Typography>
       );
     },

--- a/src/components/PortfolioTable.tsx
+++ b/src/components/PortfolioTable.tsx
@@ -89,6 +89,24 @@ const PORTFOLIO_TABLE_HEADERS_FROM_DB: Array<ColumnConfig> = [
     ),
   },
   {
+    label: "P/L",
+    key: "profitLoss",
+    render: (_, stock: PortfolioStock) => {
+      const buyPrice = stock.buyPrice ?? 0;
+      const currentPrice = stock.latestClosingPrice ?? 0;
+      const profitLoss = (currentPrice - buyPrice) * stock.quantity;
+
+      return (
+        <Typography
+          variant="body2"
+          sx={{ color: profitLoss >= 0 ? "success.main" : "error.main" }}
+        >
+          {formatAmount(profitLoss, true)}
+        </Typography>
+      );
+    },
+  },
+  {
     label: "Stop Loss",
     key: "stopLoss",
     minWidth: 150,

--- a/src/components/PortfolioTable.tsx
+++ b/src/components/PortfolioTable.tsx
@@ -99,12 +99,14 @@ const PORTFOLIO_TABLE_HEADERS_FROM_DB: Array<ColumnConfig> = [
         buyPrice !== 0 ? ((currentPrice - buyPrice) / buyPrice) * 100 : 0;
 
       return (
-        <Typography
-          variant="body2"
-          sx={{ color: profitLoss >= 0 ? "success.main" : "error.main" }}
-        >
-          {formatAmount(profitLoss, true)} ({profitLossPercent.toFixed(2)}%)
-        </Typography>
+        <Tooltip title={`${profitLossPercent.toFixed(2)}%`} arrow>
+          <Typography
+            variant="body2"
+            sx={{ color: profitLoss >= 0 ? "success.main" : "error.main" }}
+          >
+            {formatAmount(profitLoss, true)}
+          </Typography>
+        </Tooltip>
       );
     },
   },


### PR DESCRIPTION
## Summary
- display profit or loss for each stock in portfolio table

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68b40b0afa78832588d44d12c36e9893